### PR TITLE
Feat: Implement Tools page and restructure settings

### DIFF
--- a/SettingsView.js
+++ b/SettingsView.js
@@ -12,113 +12,92 @@ class SettingsView extends BaseView {
                 <h1>Settings</h1>
                 <div id="settings-content-wrapper"> 
                     <div class="settings-tabs" role="tablist">
-                        <button role="tab" aria-selected="true" aria-controls="rss-settings-panel" id="rss-tab">RSS Settings</button>
-                        <button role="tab" aria-selected="false" aria-controls="marquee-settings-panel" id="marquee-tab">Marquee Settings</button>
+                        <button role="tab" aria-selected="true" aria-controls="marquee-settings-panel" id="marquee-tab">Marquee Settings</button>
                         <button role="tab" aria-selected="false" aria-controls="theme-settings-panel" id="theme-tab">Theme Settings</button>
                     </div>
 
-                    <div id="rss-settings-panel" role="tabpanel" aria-labelledby="rss-tab">
-                        <section id="rss-settings">
-                            <h2>RSS Feed Settings</h2>
-                            <div>
-                                <label for="new-rss-feed-url">Add RSS Feed URL:</label>
-                            <input type="text" id="new-rss-feed-url" name="new-rss-feed-url" size="50" placeholder="Enter feed URL">
-                            <button id="add-new-rss-feed-url">Add Feed</button>
-                        </div>
-                        <h3>Configured Feeds:</h3>
-                        <ul id="rss-feed-urls-list">
-                            <!-- Feed URLs will be listed here by JavaScript -->
-                        </ul>
-                        <p id="rss-status-message" class="status-message" style="margin-bottom: 20px;"></p> <!-- Added margin for separation -->
-                        
-                        <h4>Display Options:</h4>
-                        <div>
-                            <label for="rss-max-items">Max items per feed (0 for all):</label>
-                            <input type="number" id="rss-max-items" min="0" value="10"> <!-- Default to 10 -->
-                        </div>
-                        <div>
-                            <input type="checkbox" id="rss-show-descriptions" checked> <!-- Default to checked -->
-                            <label for="rss-show-descriptions">Show item descriptions</label>
-                        </div>
-                        <div>
-                            <input type="checkbox" id="rss-show-dates" checked> <!-- Default to checked -->
-                            <label for="rss-show-dates">Show item publication dates</label>
-                        </div>
-                        <button id="save-rss-display-options">Save Display Options</button>
-                        <p id="rss-display-options-status-message" class="status-message"></p>
-                        </section>
-                    </div>
-                    <div id="marquee-settings-panel" role="tabpanel" aria-labelledby="marquee-tab" class="hidden">
+                    <div id="marquee-settings-panel" role="tabpanel" aria-labelledby="marquee-tab">
                         <section id="marquee-settings">
-                        <h2>Marquee Messages</h2>
-                        <div>
-                            <label for="new-marquee-message">New Message:</label>
-                        <input type="text" id="new-marquee-message" size="50">
-                        <button id="add-marquee-message">Add Message</button>
-                    </div>
-                    <h3>Current Messages:</h3>
-                    <ul id="marquee-messages-list">
-                        <!-- Messages will be listed here -->
-                    </ul>
-                    <button id="clear-marquee-messages">Clear All Marquee Messages</button>
-                    <p id="marquee-status-message" class="status-message"></p>
+                            <h2>Marquee Messages</h2>
+                            <div class="setting-entry">
+                                <label for="new-marquee-message">New Message:</label>
+                                <input type="text" id="new-marquee-message" size="50">
+                                <button id="add-marquee-message">Add Message</button>
+                            </div>
+                            <fieldset class="settings-group">
+                                <legend>Current Messages</legend>
+                                <ul id="marquee-messages-list">
+                                    <!-- Messages will be listed here -->
+                                </ul>
+                                <button id="clear-marquee-messages">Clear All Marquee Messages</button>
+                                <p id="marquee-status-message" class="status-message"></p>
+                            </fieldset>
                         </section>
                     </div>
                     <div id="theme-settings-panel" role="tabpanel" aria-labelledby="theme-tab" class="hidden">
                         <section id="theme-settings">
                             <h2>Theme Settings</h2>
-                            <div>
-                                <label for="theme-primary-bg-color">Primary Background Color:</label>
-                        <input type="color" id="theme-primary-bg-color" data-css-var="--primary-bg-color">
-                    </div>
-                    <div>
-                        <label for="theme-secondary-bg-color">Secondary Background Color:</label>
-                        <input type="color" id="theme-secondary-bg-color" data-css-var="--secondary-bg-color">
-                    </div>
-                    <div>
-                        <label for="theme-text-color">Text Color:</label>
-                        <input type="color" id="theme-text-color" data-css-var="--text-color">
-                    </div>
-                    <div>
-                        <label for="theme-link-color">Link Color:</label>
-                        <input type="color" id="theme-link-color" data-css-var="--link-color">
-                    </div>
-                    <div>
-                        <label for="theme-button-bg-color">Button Background Color:</label>
-                        <input type="color" id="theme-button-bg-color" data-css-var="--button-bg-color">
-                    </div>
-                    <div>
-                        <label for="theme-navbar-text-color">Navbar Link Text Color:</label>
-                        <input type="color" id="theme-navbar-text-color" data-css-var="--navbar-text-color">
-                    </div>
-                    <div>
-                        <label for="theme-navbar-text-hover-color">Navbar Link Hover Text Color:</label>
-                        <input type="color" id="theme-navbar-text-hover-color" data-css-var="--navbar-text-hover-color">
-                    </div>
-                    <div>
-                        <label for="theme-navbar-text-active-color">Navbar Link Active Text Color:</label>
-                        <input type="color" id="theme-navbar-text-active-color" data-css-var="--navbar-text-active-color">
-                    </div>
-                    <div>
-                        <label for="theme-navbar-border-active-color">Navbar Link Active Border Color:</label>
-                        <input type="color" id="theme-navbar-border-active-color" data-css-var="--navbar-border-active-color">
-                    </div>
-                    <div>
-                        <label for="theme-font-family">Font Family:</label>
-                        <select id="theme-font-family" data-css-var="--font-family-primary">
-                            <option value="Arial, Helvetica, sans-serif">Sans Serif (Arial)</option>
-                            <option value='-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'>System Default</option>
-                            <option value="Verdana, Geneva, sans-serif">Sans Serif (Verdana)</option>
-                            <option value="Georgia, serif">Serif (Georgia)</option>
-                            <option value="'Times New Roman', Times, serif">Serif (Times New Roman)</option>
-                            <option value="'Courier New', Courier, monospace">Monospace (Courier New)</option>
-                            <option value="'Lucida Console', Monaco, monospace">Monospace (Lucida Console)</option>
-                        </select>
-                    </div>
-                    <div style="margin-top: 20px;">
-                        <button id="save-theme-settings">Save Theme</button>
-                        <button id="reset-default-theme">Reset to Default Theme</button>
-                        <p id="theme-status-message" class="status-message"></p>
+                            <fieldset class="settings-group">
+                                <legend>Color Palette</legend>
+                                <div class="setting-entry">
+                                    <label for="theme-primary-bg-color">Primary Background Color:</label>
+                                    <input type="color" id="theme-primary-bg-color" data-css-var="--primary-bg-color">
+                                </div>
+                                <div class="setting-entry">
+                                    <label for="theme-secondary-bg-color">Secondary Background Color:</label>
+                                    <input type="color" id="theme-secondary-bg-color" data-css-var="--secondary-bg-color">
+                                </div>
+                                <div class="setting-entry">
+                                    <label for="theme-text-color">Text Color:</label>
+                                    <input type="color" id="theme-text-color" data-css-var="--text-color">
+                                </div>
+                                <div class="setting-entry">
+                                    <label for="theme-link-color">Link Color:</label>
+                                    <input type="color" id="theme-link-color" data-css-var="--link-color">
+                                </div>
+                                <div class="setting-entry">
+                                    <label for="theme-button-bg-color">Button Background Color:</label>
+                                    <input type="color" id="theme-button-bg-color" data-css-var="--button-bg-color">
+                                </div>
+                            </fieldset>
+                            <fieldset class="settings-group">
+                                <legend>Navbar Colors</legend>
+                                <div class="setting-entry">
+                                    <label for="theme-navbar-text-color">Navbar Link Text Color:</label>
+                                    <input type="color" id="theme-navbar-text-color" data-css-var="--navbar-text-color">
+                                </div>
+                                <div class="setting-entry">
+                                    <label for="theme-navbar-text-hover-color">Navbar Link Hover Text Color:</label>
+                                    <input type="color" id="theme-navbar-text-hover-color" data-css-var="--navbar-text-hover-color">
+                                </div>
+                                <div class="setting-entry">
+                                    <label for="theme-navbar-text-active-color">Navbar Link Active Text Color:</label>
+                                    <input type="color" id="theme-navbar-text-active-color" data-css-var="--navbar-text-active-color">
+                                </div>
+                                <div class="setting-entry">
+                                    <label for="theme-navbar-border-active-color">Navbar Link Active Border Color:</label>
+                                    <input type="color" id="theme-navbar-border-active-color" data-css-var="--navbar-border-active-color">
+                                </div>
+                            </fieldset>
+                            <fieldset class="settings-group">
+                                <legend>Font Settings</legend>
+                                <div class="setting-entry">
+                                    <label for="theme-font-family">Font Family:</label>
+                                    <select id="theme-font-family" data-css-var="--font-family-primary">
+                                        <option value="Arial, Helvetica, sans-serif">Sans Serif (Arial)</option>
+                                        <option value='-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"'>System Default</option>
+                                        <option value="Verdana, Geneva, sans-serif">Sans Serif (Verdana)</option>
+                                        <option value="Georgia, serif">Serif (Georgia)</option>
+                                        <option value="'Times New Roman', Times, serif">Serif (Times New Roman)</option>
+                                        <option value="'Courier New', Courier, monospace">Monospace (Courier New)</option>
+                                        <option value="'Lucida Console', Monaco, monospace">Monospace (Lucida Console)</option>
+                                    </select>
+                                </div>
+                            </fieldset>
+                            <div class="setting-entry" style="margin-top: 20px;"> <!-- Main action buttons for the theme panel -->
+                                <button id="save-theme-settings">Save Theme</button>
+                                <button id="reset-default-theme">Reset to Default Theme</button>
+                                <p id="theme-status-message" class="status-message"></p>
                             </div>
                         </section>
                     </div>
@@ -131,35 +110,6 @@ class SettingsView extends BaseView {
 
         // This logic is moved from settings.js's loadSettingsPage()
         // Ensure settings.js (for getSetting/saveSetting, etc.) and marquee.js (for message functions) are loaded globally.
-
-        // RSS Feed URLs Management
-        this.renderRssFeedUrlsList(); // Initial display of saved URLs
-        const addNewRssFeedUrlButton = document.getElementById('add-new-rss-feed-url');
-        if (addNewRssFeedUrlButton) {
-            this.boundAddRssFeedUrl = this.addRssFeedUrl.bind(this);
-            addNewRssFeedUrlButton.addEventListener('click', this.boundAddRssFeedUrl);
-        }
-
-        // RSS Display Options Logic
-        const maxItemsInput = document.getElementById('rss-max-items');
-        const showDescCheckbox = document.getElementById('rss-show-descriptions');
-        const showDatesCheckbox = document.getElementById('rss-show-dates');
-        const saveDisplayOptionsButton = document.getElementById('save-rss-display-options');
-
-        if (maxItemsInput) maxItemsInput.value = getSetting('rssDisplayOptions_maxItems', 10);
-        if (showDescCheckbox) showDescCheckbox.checked = getSetting('rssDisplayOptions_showDesc', true);
-        if (showDatesCheckbox) showDatesCheckbox.checked = getSetting('rssDisplayOptions_showDates', true);
-
-        if (saveDisplayOptionsButton) {
-            this.boundSaveRssDisplayOptions = () => { // Arrow function to bind 'this' if needed, or could be a class method
-                const maxItems = parseInt(maxItemsInput.value, 10);
-                saveSetting('rssDisplayOptions_maxItems', isNaN(maxItems) || maxItems < 0 ? 0 : maxItems);
-                saveSetting('rssDisplayOptions_showDesc', showDescCheckbox.checked);
-                saveSetting('rssDisplayOptions_showDates', showDatesCheckbox.checked);
-                displayStatusMessage('rss-display-options-status-message', 'Display options saved!');
-            };
-            saveDisplayOptionsButton.addEventListener('click', this.boundSaveRssDisplayOptions);
-        }
         
         // Marquee Messages Logic
         this.renderMarqueeMessagesList(); 
@@ -253,29 +203,6 @@ class SettingsView extends BaseView {
         // Remove event listeners added in postRender.
         // This is crucial to prevent memory leaks if the view is re-rendered.
         // For simplicity, directly query and remove. A more robust system might store listener references.
-        const addNewRssFeedUrlButton = document.getElementById('add-new-rss-feed-url');
-        if (addNewRssFeedUrlButton && this.boundAddRssFeedUrl) {
-             addNewRssFeedUrlButton.removeEventListener('click', this.boundAddRssFeedUrl);
-        }
-        
-        // Cleanup for RSS Remove buttons (if listeners were stored individually)
-        if (this.rssRemoveButtonListeners) {
-            this.rssRemoveButtonListeners.forEach(entry => {
-                entry.element.removeEventListener(entry.type, entry.listener);
-            });
-            this.rssRemoveButtonListeners = [];
-        } else { // Fallback if individual listeners weren't stored (e.g. if renderRssFeedUrlsList was modified)
-            const rssFeedList = document.getElementById('rss-feed-urls-list');
-            if (rssFeedList) {
-                // Replace to remove all listeners from children if specific ones aren't tracked
-                rssFeedList.replaceWith(rssFeedList.cloneNode(true));
-            }
-        }
-        
-        const saveDisplayOptionsButton = document.getElementById('save-rss-display-options');
-        if (saveDisplayOptionsButton && this.boundSaveRssDisplayOptions) {
-            saveDisplayOptionsButton.removeEventListener('click', this.boundSaveRssDisplayOptions);
-        }
 
         const addMarqueeBtn = document.getElementById('add-marquee-message');
         if (addMarqueeBtn) addMarqueeBtn.replaceWith(addMarqueeBtn.cloneNode(true));
@@ -292,81 +219,6 @@ class SettingsView extends BaseView {
         // console.log('SettingsView destroyed and event listeners cleaned up (via cloning).');
     }
 
-    renderRssFeedUrlsList() {
-        const urls = getSetting('rssFeedUrls', []); // Assumes getSetting is available
-        const listElement = document.getElementById('rss-feed-urls-list');
-        if (!listElement) return;
-
-        listElement.innerHTML = ''; // Clear current list
-        if (urls.length === 0) {
-            const li = document.createElement('li');
-            li.textContent = 'No RSS feeds configured.';
-            listElement.appendChild(li);
-        } else {
-            urls.forEach(url => {
-                const li = document.createElement('li');
-                
-                const urlText = document.createElement('span');
-                urlText.textContent = url;
-                urlText.style.marginRight = '10px'; // Add some spacing
-                li.appendChild(urlText);
-
-                const removeButton = document.createElement('button');
-                removeButton.textContent = 'Remove';
-                removeButton.classList.add('remove-rss-btn'); // Add class for styling/identification
-                removeButton.dataset.url = url; // Store URL for easy removal
-                
-                // Store the bound function for this specific button
-                const boundRemoveRssFeedUrl = () => this.removeRssFeedUrl(url);
-                removeButton.addEventListener('click', boundRemoveRssFeedUrl);
-                
-                // Optionally store this listener for more precise removal in destroy()
-                // if not relying on cloneNode for the list.
-                if (!this.rssRemoveButtonListeners) this.rssRemoveButtonListeners = [];
-                this.rssRemoveButtonListeners.push({element: removeButton, type: 'click', listener: boundRemoveRssFeedUrl});
-
-                li.appendChild(removeButton);
-                listElement.appendChild(li);
-            });
-        }
-    }
-
-    addRssFeedUrl() {
-        const newUrlInput = document.getElementById('new-rss-feed-url');
-        if (!newUrlInput) return;
-        const newUrl = newUrlInput.value.trim();
-
-        if (newUrl === '') {
-            displayStatusMessage('rss-status-message', 'Please enter a URL.'); // Assumes displayStatusMessage
-            return;
-        }
-        // Basic URL validation (very simple)
-        if (!newUrl.startsWith('http://') && !newUrl.startsWith('https://')) {
-            displayStatusMessage('rss-status-message', 'Invalid URL format. Must start with http:// or https://');
-            return;
-        }
-
-        const urls = getSetting('rssFeedUrls', []);
-        if (urls.includes(newUrl)) {
-            displayStatusMessage('rss-status-message', 'This URL is already in the list.');
-            return;
-        }
-
-        urls.push(newUrl);
-        saveSetting('rssFeedUrls', urls); // Assumes saveSetting is available
-        this.renderRssFeedUrlsList();
-        newUrlInput.value = ''; // Clear input
-        displayStatusMessage('rss-status-message', 'RSS Feed URL added!');
-    }
-
-    removeRssFeedUrl(urlToRemove) {
-        let urls = getSetting('rssFeedUrls', []);
-        urls = urls.filter(url => url !== urlToRemove);
-        saveSetting('rssFeedUrls', urls);
-        this.renderRssFeedUrlsList(); // Re-render the list, which will also re-attach listeners
-        displayStatusMessage('rss-status-message', 'RSS Feed URL removed!');
-    }
-
     setupTabs() {
         const tabButtons = document.querySelectorAll('.settings-tabs button[role="tab"]');
         const tabPanels = document.querySelectorAll('div[role="tabpanel"]');
@@ -374,8 +226,25 @@ class SettingsView extends BaseView {
         // Set initial state: first tab active, others hidden (already done in HTML for panels)
         // Ensure first tab button has aria-selected="true" (already in HTML)
         // Ensure corresponding panel is visible (remove 'hidden' class if present)
-        const initialActivePanelId = document.querySelector('.settings-tabs button[aria-selected="true"]').getAttribute('aria-controls');
-        document.getElementById(initialActivePanelId)?.classList.remove('hidden');
+        // const initialActivePanelId = document.querySelector('.settings-tabs button[aria-selected="true"]').getAttribute('aria-controls');
+        // document.getElementById(initialActivePanelId)?.classList.remove('hidden');
+        // Make sure the first tab and its panel are active by default.
+        if (tabButtons.length > 0) {
+            const firstTab = tabButtons[0];
+            firstTab.setAttribute('aria-selected', 'true');
+            const firstPanelId = firstTab.getAttribute('aria-controls');
+            const firstPanel = document.getElementById(firstPanelId);
+            if (firstPanel) {
+                firstPanel.classList.remove('hidden');
+            }
+
+            // Hide other panels
+            tabPanels.forEach(panel => {
+                if (panel.id !== firstPanelId) {
+                    panel.classList.add('hidden');
+                }
+            });
+        }
 
 
         tabButtons.forEach(button => {

--- a/ToolsView.js
+++ b/ToolsView.js
@@ -1,0 +1,259 @@
+// ToolsView.js
+class ToolsView extends BaseView {
+    constructor() {
+        super();
+    }
+
+    // Store bound event handlers for potential cleanup in destroy, if needed for complex tools
+    // For this RSS tool, since we overwrite innerHTML, explicit removal might not be strictly necessary
+    // if all listeners are on elements within the toolDisplayArea.
+    // However, it's good practice for more complex scenarios.
+    boundToolEventHandlers = [];
+
+    _clearToolDisplayArea(toolDisplayArea, defaultMessage) {
+        toolDisplayArea.innerHTML = defaultMessage;
+        // Clean up any dynamically added listeners from the previous tool
+        this.boundToolEventHandlers.forEach(handler => {
+            if (handler.element && handler.event && handler.listener) {
+                 handler.element.removeEventListener(handler.event, handler.listener);
+            }
+        });
+        this.boundToolEventHandlers = [];
+    }
+
+    _renderRssFeedUrlsList() {
+        const urls = getSetting('rssFeedUrls', []);
+        // Assuming the list element will be inside the toolDisplayArea after _renderRssReaderToolHtml
+        const listElement = document.getElementById('rss-feed-urls-list-tool'); 
+        if (!listElement) {
+            console.warn("Element 'rss-feed-urls-list-tool' not found during _renderRssFeedUrlsList.");
+            return;
+        }
+
+        listElement.innerHTML = ''; // Clear current list
+        if (urls.length === 0) {
+            const li = document.createElement('li');
+            li.textContent = 'No RSS feeds configured.';
+            listElement.appendChild(li);
+        } else {
+            urls.forEach(url => {
+                const li = document.createElement('li');
+                
+                const urlText = document.createElement('span');
+                urlText.textContent = url;
+                urlText.style.marginRight = '10px';
+                li.appendChild(urlText);
+
+                const removeButton = document.createElement('button');
+                removeButton.textContent = 'Remove';
+                removeButton.classList.add('remove-rss-btn');
+                // removeButton.dataset.url = url; // Data attribute not strictly needed if using closure
+                
+                // Event listener for remove button
+                const removeHandler = () => this._handleRemoveRssFeedUrl(url);
+                removeButton.addEventListener('click', removeHandler);
+                // Store for potential cleanup, though in this case, innerHTML overwrite handles it.
+                // this.boundToolEventHandlers.push({element: removeButton, event: 'click', listener: removeHandler});
+
+
+                li.appendChild(removeButton);
+                listElement.appendChild(li);
+            });
+        }
+    }
+
+    _handleRemoveRssFeedUrl(urlToRemove) {
+        let urls = getSetting('rssFeedUrls', []);
+        urls = urls.filter(url => url !== urlToRemove);
+        saveSetting('rssFeedUrls', urls);
+        this._renderRssFeedUrlsList(); // Re-render the list
+        displayStatusMessage('rss-status-message-tool', 'RSS Feed URL removed!');
+    }
+    
+    _renderRssReaderToolHtml() {
+        // Using unique IDs for elements within the tool by appending "-tool"
+        return `
+            <section id="rss-settings-tool">
+                <h2>RSS Feed Settings</h2>
+                <div class="setting-entry">
+                    <label for="new-rss-feed-url-input-tool">Add RSS Feed URL:</label>
+                    <input type="text" id="new-rss-feed-url-input-tool" name="new-rss-feed-url-tool" size="50" placeholder="Enter feed URL">
+                    <button id="add-new-rss-feed-url-button-tool">Add Feed</button>
+                </div>
+                <fieldset class="settings-group">
+                    <legend>Configured Feeds</legend>
+                    <ul id="rss-feed-urls-list-tool"></ul>
+                    <p id="rss-status-message-tool" class="status-message"></p>
+                </fieldset>
+                <fieldset class="settings-group">
+                    <legend>Display Options</legend>
+                    <div class="setting-entry">
+                        <label for="rss-max-items-input-tool">Max items per feed (0 for all):</label>
+                        <input type="number" id="rss-max-items-input-tool" min="0">
+                    </div>
+                    <div class="setting-entry">
+                        <input type="checkbox" id="rss-show-descriptions-checkbox-tool">
+                        <label for="rss-show-descriptions-checkbox-tool">Show item descriptions</label>
+                    </div>
+                    <div class="setting-entry">
+                        <input type="checkbox" id="rss-show-dates-checkbox-tool">
+                        <label for="rss-show-dates-checkbox-tool">Show item publication dates</label>
+                    </div>
+                    <button id="save-rss-display-options-button-tool">Save Display Options</button>
+                    <p id="rss-display-options-status-message-tool" class="status-message"></p>
+                </fieldset>
+            </section>
+        `;
+    }
+
+    _initRssReaderToolLogic() {
+        this._renderRssFeedUrlsList(); 
+
+        const addBtn = document.getElementById('add-new-rss-feed-url-button-tool');
+        const newUrlInput = document.getElementById('new-rss-feed-url-input-tool');
+        
+        if (addBtn && newUrlInput) {
+            const addFeedHandler = () => {
+                const newUrl = newUrlInput.value.trim();
+                if (newUrl === '') {
+                    displayStatusMessage('rss-status-message-tool', 'Please enter a URL.');
+                    return;
+                }
+                if (!newUrl.startsWith('http://') && !newUrl.startsWith('https://')) {
+                    displayStatusMessage('rss-status-message-tool', 'Invalid URL format. Must start with http:// or https://');
+                    return;
+                }
+                const urls = getSetting('rssFeedUrls', []);
+                if (urls.includes(newUrl)) {
+                    displayStatusMessage('rss-status-message-tool', 'This URL is already in the list.');
+                    return;
+                }
+                urls.push(newUrl);
+                saveSetting('rssFeedUrls', urls);
+                this._renderRssFeedUrlsList();
+                newUrlInput.value = '';
+                displayStatusMessage('rss-status-message-tool', 'RSS Feed URL added!');
+            };
+            addBtn.addEventListener('click', addFeedHandler);
+            // this.boundToolEventHandlers.push({element: addBtn, event: 'click', listener: addFeedHandler});
+        }
+
+        // Note: Event listeners for "Remove" buttons are added directly in _renderRssFeedUrlsList
+
+        const maxItemsInput = document.getElementById('rss-max-items-input-tool');
+        const showDescCheckbox = document.getElementById('rss-show-descriptions-checkbox-tool');
+        const showDatesCheckbox = document.getElementById('rss-show-dates-checkbox-tool');
+        const saveDisplayOptionsBtn = document.getElementById('save-rss-display-options-button-tool');
+
+        if (maxItemsInput) maxItemsInput.value = getSetting('rssDisplayOptions_maxItems', 10);
+        if (showDescCheckbox) showDescCheckbox.checked = getSetting('rssDisplayOptions_showDesc', true);
+        if (showDatesCheckbox) showDatesCheckbox.checked = getSetting('rssDisplayOptions_showDates', true);
+
+        if (saveDisplayOptionsBtn) {
+            const saveOptionsHandler = () => {
+                const maxItems = parseInt(maxItemsInput.value, 10);
+                saveSetting('rssDisplayOptions_maxItems', isNaN(maxItems) || maxItems < 0 ? 0 : maxItems);
+                saveSetting('rssDisplayOptions_showDesc', showDescCheckbox.checked);
+                saveSetting('rssDisplayOptions_showDates', showDatesCheckbox.checked);
+                displayStatusMessage('rss-display-options-status-message-tool', 'Display options saved!');
+            };
+            saveDisplayOptionsBtn.addEventListener('click', saveOptionsHandler);
+            // this.boundToolEventHandlers.push({element: saveDisplayOptionsBtn, event: 'click', listener: saveOptionsHandler});
+        }
+    }
+    
+    render() {
+        return `
+            <div class="page-container">
+                <h1>Tools</h1>
+                <div id="tools-content-wrapper">
+                    <div id="tool-selection-area">
+                        <h2>Tool Categories</h2>
+                        
+                        <div class="tool-category">
+                            <label for="category-content-utils">Content Utilities:</label>
+                            <select id="category-content-utils" class="tool-category-dropdown" data-category="Content Utilities">
+                                <option value="">-- Select a tool --</option>
+                                <option value="rss-reader-tool">RSS Reader (View)</option> 
+                                <option value="marquee-editor">Marquee Editor (Placeholder)</option>
+                            </select>
+                        </div>
+
+                        <div class="tool-category">
+                            <label for="category-data-utils">Data Utilities:</label>
+                            <select id="category-data-utils" class="tool-category-dropdown" data-category="Data Utilities">
+                                <option value="">-- Select a tool --</option>
+                                <option value="json-formatter">JSON Formatter (Placeholder)</option>
+                                <option value="list-randomizer-tool">List Randomizer (View)</option>
+                            </select>
+                        </div>
+                        
+                        <div class="tool-category">
+                            <label for="category-misc-utils">Miscellaneous:</label>
+                            <select id="category-misc-utils" class="tool-category-dropdown" data-category="Miscellaneous">
+                                <option value="">-- Select a tool --</option>
+                                <option value="coin-flipper-tool">Coin Flipper (View)</option>
+                                <option value="random-number-tool">Random Number Gen (View)</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <div id="tool-display-area">
+                        <p>Select a tool from a category above to see its interface here.</p>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+
+    postRender() {
+        const toolDropdowns = document.querySelectorAll('.tool-category-dropdown');
+        const toolDisplayArea = document.getElementById('tool-display-area');
+        const defaultDisplayAreaMessage = '<p>Select a tool from a category above to see its interface here.</p>';
+
+        toolDropdowns.forEach(dropdown => {
+            dropdown.addEventListener('change', (event) => {
+                const selectedToolValue = event.target.value;
+                
+                // Clear previous tool's UI and listeners before loading new one
+                this._clearToolDisplayArea(toolDisplayArea, defaultDisplayAreaMessage);
+
+                if (selectedToolValue) {
+                    const selectedToolOption = event.target.options[event.target.selectedIndex];
+                    const selectedToolName = selectedToolOption.text;
+                    const category = event.target.dataset.category;
+
+                    // Deselect other dropdowns
+                    toolDropdowns.forEach(otherDropdown => {
+                        if (otherDropdown !== event.target) {
+                            otherDropdown.value = ""; 
+                        }
+                    });
+                    
+                    console.log(`Tool selected: ${selectedToolName} (Value: ${selectedToolValue}), Category: ${category}`);
+
+                    if (selectedToolValue === "rss-reader-tool") {
+                        toolDisplayArea.innerHTML = this._renderRssReaderToolHtml();
+                        this._initRssReaderToolLogic();
+                    } else {
+                        // Placeholder for other tools
+                        toolDisplayArea.innerHTML = `<h3>${selectedToolName} Interface</h3><p>Tool UI for <strong>${selectedToolName}</strong> (from category: ${category}) will be here.</p><p><small>Value: ${selectedToolValue}</small></p>`;
+                    }
+                } 
+                // If selectedToolValue is empty, _clearToolDisplayArea has already reset it.
+            });
+        });
+    }
+
+    destroy() {
+        // console.log("ToolsView destroyed");
+        // Clean up any dynamically added listeners from the last active tool
+        // This is a fallback if a view is destroyed without clearing the tool display first
+        const toolDisplayArea = document.getElementById('tool-display-area');
+        if (toolDisplayArea) {
+             this._clearToolDisplayArea(toolDisplayArea, ''); // Clear with empty message
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <script type="text/javascript" src="RandomNumberView.js"></script>
     <script type="text/javascript" src="CoinFlipperView.js"></script>
     <script type="text/javascript" src="TarkovRouletteView.js"></script> <!-- Added TarkovRouletteView -->
+    <script type="text/javascript" src="ToolsView.js"></script> <!-- Added ToolsView -->
     <script type="text/javascript" src="App.js"></script>
     <!-- Specific View class files will be created later -->
 
@@ -56,7 +57,8 @@
                 typeof RandomListerView === 'function' &&
                 typeof RandomNumberView === 'function' &&
                 typeof CoinFlipperView === 'function' &&
-                typeof TarkovRouletteView === 'function') {
+                typeof TarkovRouletteView === 'function' &&
+                typeof ToolsView === 'function') { // Added ToolsView check
                 const appRoutes = {
                     '#home': RssFeedView,
                     '#settings': SettingsView,
@@ -64,6 +66,7 @@
                     '#random-number': RandomNumberView,
                     '#coin-flipper': CoinFlipperView,
                     '#tarkov-roulette': TarkovRouletteView,
+                    '#tools': ToolsView, // Added ToolsView route
                 };
                 new App(appRoutes);
             } else {

--- a/menu.html
+++ b/menu.html
@@ -5,6 +5,7 @@
         <li><a href="#random-number">Random Number</a></li>
         <li><a href="#coin-flipper">Coin Flipper</a></li>
         <li><a href="#tarkov-roulette">Tarkov Roulette</a></li>
+        <li><a href="#tools" id="tools-nav">Tools</a></li>
         <li><a href="#settings">Settings</a></li>
     </ul>
 </nav>

--- a/style.css
+++ b/style.css
@@ -294,32 +294,113 @@ div[role="tabpanel"].hidden { /* Class to hide panels */
 /* Updated to target h2 within sections inside tab panels */
 #settings-content-wrapper section h2 {
     margin-top: 0; /* Reset top margin as panel provides spacing */
-    margin-bottom: 15px;
+    margin-bottom: 20px; /* Increased margin for separation from first fieldset */
     padding-bottom: 10px;
     border-bottom: 1px solid var(--border-color-light);
     color: var(--heading-text-color);
 }
 
-#settings-content p {
+/* General p styling within settings, if needed, but specific classes are better */
+/* #settings-content-wrapper section p {
     margin-bottom: 15px;
     line-height: 1.7;
-}
-#settings-content-wrapper section label { /* Target labels within sections */
+} */
+
+/* Remove old generic label/input styling for settings, replaced by .setting-entry */
+/* #settings-content-wrapper section label { 
     display: inline-block;
-    min-width: 200px; /* Align input fields */
+    min-width: 200px; 
     margin-bottom: 8px;
 }
 #settings-content-wrapper section input[type="color"], 
 #settings-content-wrapper section select {
-    margin-left: 10px; /* Space after label */
-}
-/* Remove hr if sections are now visually separated by tabs or panel borders */
+    margin-left: 10px; 
+} */
+
+/* Remove hr as sections are now visually separated by tabs or panel borders */
 #settings-content-wrapper hr {
     display: none; 
 }
 
+/* Setting Entry: for individual label-input pairs */
+.setting-entry {
+    margin-bottom: 15px;
+    display: flex; /* Use flex for alignment */
+    flex-wrap: wrap; /* Allow wrapping for smaller screens or long content */
+    align-items: center; /* Vertically align items */
+}
+.setting-entry label {
+    min-width: 250px; /* Adjusted min-width for labels */
+    margin-right: 10px; /* Space between label and input */
+    margin-bottom: 5px; /* Spacing if wraps */
+    flex-shrink: 0; /* Prevent label from shrinking */
+}
+.setting-entry input[type="text"],
+.setting-entry input[type="number"],
+.setting-entry input[type="color"],
+.setting-entry select {
+    flex-grow: 1; /* Allow input to take available space */
+    max-width: 350px; /* Max width for inputs */
+    margin-left: 0; /* Reset margin if set by general input styles */
+}
+.setting-entry input[type="checkbox"] { /* Specific for checkbox alignment */
+    margin-right: 0; /* Remove general input margin if any */
+}
+.setting-entry input[type="checkbox"] + label { /* Style for checkbox labels to align them nicely */
+    min-width: auto; /* Override general label min-width */
+    margin-left: 5px;
+    margin-right: 0;
+    flex-shrink: 1; /* Allow checkbox label to shrink/wrap if needed */
+}
+.setting-entry button { /* For buttons inside a setting-entry, like 'Add Feed' */
+    margin-left: 10px;
+}
+.setting-entry .status-message { /* For status messages tied to a specific entry, if any */
+    margin-left: 10px; /* Example */
+    font-size: 0.9em;
+    flex-basis: 100%; /* Make status message take full width if it wraps */
+    margin-top: 5px;
+}
 
-.status-message {
+/* Settings Group: for fieldsets grouping related settings */
+.settings-group {
+    border: 1px solid var(--border-color-light);
+    padding: 20px; /* Increased padding */
+    margin-bottom: 25px; /* Increased margin */
+    border-radius: 4px;
+}
+.settings-group legend {
+    font-size: 1.1em; /* Larger than normal text, smaller than h2 */
+    font-weight: bold;
+    color: var(--heading-text-color);
+    padding: 0 10px; /* Spacing around the legend text */
+    margin-left: 5px; /* Align with fieldset padding - check visual */
+}
+.settings-group ul { /* Styling for lists within settings groups */
+    list-style-type: none;
+    padding-left: 0;
+    margin-bottom: 15px;
+}
+.settings-group li {
+    padding: 5px 0;
+    border-bottom: 1px solid var(--border-color-medium);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.settings-group li:last-child {
+    border-bottom: none;
+}
+.settings-group button { /* Buttons directly under fieldset, not in .setting-entry */
+    margin-right: 10px; /* Space between multiple buttons */
+}
+.settings-group .status-message { /* For status messages tied to a group */
+    margin-top: 10px;
+    /* display: block; /* Ensure it takes its own line if needed */
+}
+
+
+.status-message { /* General status message styling, ensure consistency */
     font-size: 0.9em;
     color: var(--text-color); /* Use general text color, or a specific status color */
     opacity: 0.8; /* Make it slightly muted */
@@ -367,4 +448,45 @@ div[role="tabpanel"].hidden { /* Class to hide panels */
     font-size: 0.9em;
     margin-bottom: 15px;
     line-height: 1.5;
+}
+
+/* Tools Page Specific Styles */
+#tool-selection-area {
+    margin-bottom: 20px;
+    padding: 15px;
+    background-color: var(--secondary-bg-color); /* Match settings page container */
+    border: 1px solid var(--border-color-light);
+    border-radius: 5px;
+}
+
+.tool-category {
+    margin-bottom: 15px;
+}
+
+.tool-category label {
+    display: block; /* Or inline-block with a set width */
+    margin-bottom: 5px;
+    font-weight: bold;
+    color: var(--heading-text-color);
+}
+
+.tool-category-dropdown {
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--border-color-medium);
+    background-color: var(--primary-bg-color);
+    color: var(--text-color);
+    min-width: 250px; /* Adjust as needed */
+}
+
+#tool-display-area {
+    padding: 20px;
+    border: 1px solid var(--border-color-light);
+    border-radius: 5px;
+    min-height: 200px;
+    background-color: var(--secondary-bg-color);
+}
+#tool-display-area h3 {
+    margin-top: 0;
+    color: var(--heading-text-color);
 }


### PR DESCRIPTION
This commit introduces a new "Tools" page and refactors the settings presentation and organization.

Key changes:
- Standardized the HTML structure and styling of settings in the main Settings page (`SettingsView.js`) for better consistency and maintainability, using new CSS classes like `.setting-entry` and `.settings-group`.
- Created a new "Tools" page (`ToolsView.js`) accessible via main navigation.
- Implemented tool categorization on the Tools page using dropdown menus for selecting tools within categories like "Content Utilities" and "Data Utilities". A dedicated area displays the selected tool's UI.
- Relocated the RSS feed settings from the main Settings page to the Tools page. These settings now appear when the "RSS Reader" tool is selected. This involved moving HTML rendering, event listeners, and settings logic to `ToolsView.js`.
- The main Settings page now focuses on more global application settings like Theme and Marquee messages.
- The "Marquee Settings" tab is now the default active tab on the Settings page.

This new structure provides a scalable way to add more tools and their specific configurations in the future.