### PR TITLE
Debug: Apply temporary styles to diagnose navbar dropdown issues

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@ a:hover {
     position: absolute;
     top: 100%; 
     left: 0;
-    background-color: var(--navbar-bg-color); 
+    /* background-color: var(--navbar-bg-color); */
     border: 1px solid var(--border-color-light); 
     border-top: none; 
     padding: 0;
@@ -120,6 +120,9 @@ a:hover {
     min-width: 200px; 
     z-index: 1001; 
     box-shadow: 0px 3px 5px rgba(0,0,0,0.2); 
+    /* Debugging Styles */
+    background-color: #333 !important;
+    overflow: visible !important;
 }
 
 .navbar li.dropdown-category:hover > ul.dropdown-menu {
@@ -127,24 +130,40 @@ a:hover {
 }
 
 .navbar ul.dropdown-menu li {
-    display: block; 
+    display: block !important; /* Or list-item */
+    /* Debugging Styles */
+    border: 1px dotted red !important;
+    overflow: visible !important;
+    height: auto !important;
 }
 
 .navbar ul.dropdown-menu li a {
-    display: block; 
+    display: block !important; 
     padding: 10px 15px;
-    color: var(--heading-text-color); /* Changed to heading text color for better contrast */
-    background-color: var(--navbar-bg-color); /* Ensuring background is explicitly set */
+    /* color: var(--heading-text-color); */ 
+    /* background-color: var(--navbar-bg-color); */
     text-decoration: none;
-    border-bottom: none; /* Override general .navbar a border if it exists */
-    font-size: calc(var(--base-font-size) * 0.95); 
-    text-align: left; /* Align text to the left for dropdown items */
+    border-bottom: none !important; 
+    /* font-size: calc(var(--base-font-size) * 0.95);  */
+    text-align: left !important; 
+
+    /* Debugging Styles */
+    color: yellow !important;
+    font-size: 14px !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    text-indent: 0 !important;
+    overflow: visible !important;
+    border: 1px dotted lime !important;
+    height: auto !important;
+    line-height: normal !important;
+    background-color: navy !important;
 }
 
 .navbar ul.dropdown-menu li a:hover {
-    background-color: var(--button-hover-bg-color); 
+    background-color: var(--button-hover-bg-color) !important; 
     /* color: var(--heading-text-color); Already set, or could be different for hover */
-    border-bottom: none; 
+    border-bottom: none !important; 
 }
 /* End Dropdown Menu Styling */
 


### PR DESCRIPTION
This commit adds temporary, highly visible debugging styles to style.css for the navbar dropdown menus (`.navbar ul.dropdown-menu li a`, `.navbar ul.dropdown-menu li`, and `.navbar ul.dropdown-menu`).

The purpose of these styles is to help you diagnose issues with text visibility and item layout by:
- Forcing specific, contrasting colors for text and backgrounds.
- Forcing specific font sizes and text rendering properties.
- Adding distinct borders to visualize element boundaries and layout.

These styles are intended for diagnostic purposes only and should be reverted before applying a final fix.