### PR TITLE
Debug: Force padding on navbar dropdown links

### DIFF
--- a/style.css
+++ b/style.css
@@ -139,7 +139,7 @@ a:hover {
 
 .navbar ul.dropdown-menu li a {
     display: block !important; 
-    padding: 10px 15px;
+    /* padding: 10px 15px; */ /* Original padding, now forced below */
     /* color: var(--heading-text-color); */ 
     /* background-color: var(--navbar-bg-color); */
     text-decoration: none;
@@ -158,6 +158,7 @@ a:hover {
     height: auto !important;
     line-height: normal !important;
     background-color: navy !important;
+    padding: 10px 15px !important; /* Force padding */
 }
 
 .navbar ul.dropdown-menu li a:hover {


### PR DESCRIPTION
This commit updates the temporary debugging styles in style.css for `.navbar ul.dropdown-menu li a` to explicitly force `padding` using `!important`.

This is to help diagnose why text might not be visible within the link areas, by ensuring that lack of internal padding is not the cause.

These styles are intended for diagnostic purposes only.