### PR TITLE
Debug: Force overflow:visible and height:auto on dropdown containers

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,6 +99,9 @@ a:hover {
 .navbar li.dropdown-category {
     position: relative; 
     display: inline-block; 
+    /* Debugging Styles */
+    overflow: visible !important;
+    height: auto !important;
 }
 
 .navbar li.dropdown-category > a {
@@ -123,6 +126,8 @@ a:hover {
     /* Debugging Styles */
     background-color: #333 !important;
     overflow: visible !important;
+    height: auto !important;
+    max-height: none !important;
 }
 
 .navbar li.dropdown-category:hover > ul.dropdown-menu {


### PR DESCRIPTION
This commit updates the temporary debugging styles in style.css for `.navbar ul.dropdown-menu` and `.navbar li.dropdown-category`.

- Sets `overflow: visible !important;`, `height: auto !important;`, and `max-height: none !important;` on these elements.
- This is to diagnose and temporarily fix issues where dropdown content might be "cut off" or "partially visible," preventing all items from being seen.

All other previous debugging styles (forced colors, borders, etc.) for child elements are maintained. These styles are intended for diagnostic purposes only.