### PR TITLE
Fix: Correct dropdown menu visibility by changing navbar overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ a:hover {
 /* Navigation Bar */
 .navbar {
 	text-align: center;
-	overflow: hidden;
+	overflow: visible;
 	background-color: var(--navbar-bg-color);
 	padding: 10px 0;
 }


### PR DESCRIPTION
The dropdown menus were being cut off because the parent .navbar container had `overflow: hidden;` set. This commit changes it to `overflow: visible;` to allow the dropdowns to extend beyond the navbar's bounds and be fully visible.

Further testing will be conducted after deployment to ensure this resolves the issue and to check for any unintended side effects or remaining text visibility problems within the dropdown items.