### PR TITLE
Style: Simplify dropdown CSS and remove debug overrides

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,8 +100,6 @@ a:hover {
     position: relative; 
     display: inline-block; 
     /* Debugging Styles */
-    overflow: visible !important;
-    height: auto !important;
 }
 
 .navbar li.dropdown-category > a {
@@ -124,10 +122,6 @@ a:hover {
     z-index: 1001; 
     box-shadow: 0px 3px 5px rgba(0,0,0,0.2); 
     /* Debugging Styles */
-    background-color: #333 !important;
-    overflow: visible !important;
-    height: auto !important;
-    max-height: none !important;
 }
 
 .navbar li.dropdown-category:hover > ul.dropdown-menu {
@@ -135,35 +129,22 @@ a:hover {
 }
 
 .navbar ul.dropdown-menu li {
-    display: block !important; /* Or list-item */
+    display: block; /* Or list-item */
     /* Debugging Styles */
-    border: 1px dotted red !important;
-    overflow: visible !important;
-    height: auto !important;
 }
 
 .navbar ul.dropdown-menu li a {
-    display: block !important; 
+    display: block; 
     /* padding: 10px 15px; */ /* Original padding, now forced below */
     /* color: var(--heading-text-color); */ 
     /* background-color: var(--navbar-bg-color); */
     text-decoration: none;
-    border-bottom: none !important; 
+    border-bottom: none; 
     /* font-size: calc(var(--base-font-size) * 0.95);  */
-    text-align: left !important; 
+    text-align: left; /* This !important might be needed depending on specificity */
 
     /* Debugging Styles */
-    color: yellow !important;
-    font-size: 14px !important;
-    opacity: 1 !important;
-    visibility: visible !important;
-    text-indent: 0 !important;
-    overflow: visible !important;
-    border: 1px dotted lime !important;
-    height: auto !important;
-    line-height: normal !important;
-    background-color: navy !important;
-    padding: 10px 15px !important; /* Force padding */
+    padding: 10px 15px; /* Force padding */
 }
 
 .navbar ul.dropdown-menu li a:hover {


### PR DESCRIPTION
Removed aggressive !important tags and debugging styles (forced colors, borders, overflow, height) from the navbar dropdown CSS. The goal is to rely on more standard CSS behavior for hover and display of dropdown menus and their items.

This change is intended to address an issue where dropdown items, particularly those after the first, were reportedly not displaying or interacting correctly. Simplifying the CSS will help determine if the issue was due to conflicting overrides.

Further testing by you will confirm if this resolves the dropdown display problem.