### PR TITLE
Style: Align dropdown item hover background with theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -146,7 +146,7 @@ a:hover {
 }
 
 .navbar ul.dropdown-menu li a:hover {
-    background-color: var(--button-hover-bg-color); 
+    background-color: var(--secondary-bg-color); 
     /* color: var(--heading-text-color); Already set, or could be different for hover */
     border-bottom: none; 
 }


### PR DESCRIPTION
Updated the `background-color` for `.navbar ul.dropdown-menu li a:hover` to use `var(--secondary-bg-color)`. This change ensures that the hover effect on individual dropdown items (e.g., "RSS Reader") is consistent with the overall theme and provides a more subtle visual feedback compared to the previous hardcoded or button-hover color.

The `!important` flag was also confirmed to be removed from this property to allow for better theme integration and prevent override issues.